### PR TITLE
Fix typo in `sshComand` -> `sshCommand`

### DIFF
--- a/_posts/2021-02-19-configure-git-windows-openssh.md
+++ b/_posts/2021-02-19-configure-git-windows-openssh.md
@@ -27,7 +27,7 @@ ssh-add ~/.ssh/id_rsa
 And here's the bit that I was missing and was driving me nuts: actually configure git to use the ssh agent you added the key to:
 
 ```bash
-git config --global core.sshComand C:/Windows/System32/OpenSSH/ssh.exe
+git config --global core.sshCommand C:/Windows/System32/OpenSSH/ssh.exe
 ```
 
 It should now no longer keep pestering you for your password.


### PR DESCRIPTION
Hey, your blogpost showed up when I was trying to find help setting up ssh agent on windows, and It looked nice and straight to the point, and I've spent about an hour utterly confused as to why git isn't picking up ssh keys from my agent while `ssh` itself works as expected, turns out it was because of me copy-pasting the `git config (...)` snippet -_-

